### PR TITLE
Add version selector with tab UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,12 @@
 </head>
 <body class="min-h-screen flex flex-col items-center justify-start bg-gray-100 relative bg-[url('assets/background.jpg')] bg-cover bg-center font-sans">
   <div class="absolute inset-0 bg-black/30 backdrop-blur -z-10"></div>
+  <div id="version-tabs" class="flex justify-center space-x-4 mt-4">
+    <button data-version="v11.4" class="version-tab px-4 py-2 border-b-2 border-transparent">v11.4</button>
+    <button data-version="v11.5" class="version-tab px-4 py-2 border-b-2 border-transparent">v11.5</button>
+    <button data-version="v11.6" class="version-tab px-4 py-2 border-b-2 border-transparent">v11.6</button>
+  </div>
+  <div id="version-info" class="hidden text-center text-yellow-800 bg-yellow-100 rounded p-2 mt-2 mx-auto text-sm w-fit"></div>
   <main class="container mx-auto p-4 flex flex-col md:flex-row gap-4 fade-in">
     <aside class="md:w-1/3 bg-orange-800/90 text-white backdrop-blur-lg p-6 rounded-lg flex items-center text-center flex-col space-y-4">
       <img src="assets/calculator.svg" alt="Calculator icon" class="w-10 h-10"/>
@@ -68,11 +74,12 @@
           <label for="gateways" class="font-medium">Print gateways: <span id="gateways-value"></span></label>
           <input type="range" id="gateways" min="1" max="10" value="1" class="w-full transition-all duration-300 rounded-lg">
         </div>
-        <div class="flex items-center space-x-2">
+        <div id="optimized-driver-section" class="flex items-center space-x-2">
           <input type="checkbox" id="optimized-driver" class="transition-all duration-300 rounded">
           <label for="optimized-driver" class="font-medium">Optimized driver?</label>
         </div>
-        <fieldset class="border rounded-lg p-4">
+        
+<fieldset id="label-characteristics-section" class="border rounded-lg p-4">
           <legend class="font-medium">Label characteristics</legend>
           <div class="flex flex-col gap-2 mt-2">
             <label class="inline-flex items-center space-x-2"><input type="checkbox" id="contains-text" class="rounded"> <span>Contains text</span></label>

--- a/script.js
+++ b/script.js
@@ -50,6 +50,33 @@ function bindInput(id, valueId) {
   if (valueId) updateDisplay(id, valueId);
 }
 
+function setVersion(version) {
+  const driver = document.getElementById('optimized-driver-section');
+  const labels = document.getElementById('label-characteristics-section');
+  const info = document.getElementById('version-info');
+  document.querySelectorAll('.version-tab').forEach(tab => {
+    if (tab.dataset.version === version) {
+      tab.classList.add('border-blue-600', 'font-bold');
+    } else {
+      tab.classList.remove('border-blue-600', 'font-bold');
+    }
+  });
+  if (version === 'v11.4') {
+    driver.classList.add('hidden');
+    labels.classList.add('hidden');
+    info.classList.add('hidden');
+  } else if (version === 'v11.5') {
+    driver.classList.remove('hidden');
+    labels.classList.remove('hidden');
+    info.classList.add('hidden');
+  } else if (version === 'v11.6') {
+    driver.classList.remove('hidden');
+    labels.classList.remove('hidden');
+    info.textContent = '⚠️ Version 11.6 is still in progress and will be available in August.';
+    info.classList.remove('hidden');
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   bindInput('labels-per-page', 'labels-per-page-value');
   bindInput('total-labels', 'total-labels-value');
@@ -62,6 +89,9 @@ document.addEventListener('DOMContentLoaded', () => {
   bindInput('contains-barcodes');
   bindInput('external-data');
   calculate();
+  const tabs = document.querySelectorAll('.version-tab');
+  tabs.forEach(t => t.addEventListener('click', () => setVersion(t.dataset.version)));
+  setVersion('v11.5');
   const btn = document.getElementById('assumptions-btn');
   if (btn) {
     btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add Tailwind styled version tabs at the top of the page
- hide/show the Optimized Driver and Label Characteristics controls based on the selected version
- show an informational banner for v11.6
- default to v11.5 and wire up tab behaviour in JS

## Testing
- `node server.js >/tmp/server.log 2>&1 &`
- `ps -ef | grep node`
- `kill %1`

------
https://chatgpt.com/codex/tasks/task_e_6862d3bc4e7883249c88e61e6451342c