### PR TITLE
Update calculator layout and behaviors

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,14 +28,15 @@
 </head>
 <body class="min-h-screen flex flex-col items-center justify-start bg-gray-100 relative bg-[url('assets/background.jpg')] bg-cover bg-center font-sans">
   <div class="absolute inset-0 bg-black/30 backdrop-blur -z-10"></div>
-  <div id="version-tabs" class="flex justify-center space-x-4 mt-4">
-    <button data-version="v11.4" class="version-tab px-4 py-2 border-b-2 border-transparent">v11.4</button>
-    <button data-version="v11.5" class="version-tab px-4 py-2 border-b-2 border-transparent">v11.5</button>
-    <button data-version="v11.6" class="version-tab px-4 py-2 border-b-2 border-transparent">v11.6</button>
+  <div class="w-full bg-gray-50 py-2">
+    <div id="version-tabs" class="flex justify-center space-x-4">
+      <button data-version="v11.4" class="version-tab px-4 py-2 border-b-2 border-transparent">v11.4</button>
+      <button data-version="v11.5" class="version-tab px-4 py-2 border-b-2 border-transparent">v11.5</button>
+      <button data-version="v11.6" class="version-tab px-4 py-2 border-b-2 border-transparent">v11.6</button>
+    </div>
   </div>
-  <div id="version-info" class="hidden text-center text-yellow-800 bg-yellow-100 rounded p-2 mt-2 mx-auto text-sm w-fit"></div>
   <main class="container mx-auto p-4 flex flex-col md:flex-row gap-4 fade-in">
-    <aside class="md:w-1/3 bg-orange-800/90 text-white backdrop-blur-lg p-6 rounded-lg flex items-center text-center flex-col space-y-4">
+    <aside class="md:w-1/3 bg-orange-300 text-orange-900 backdrop-blur-lg p-6 rounded-lg flex items-center text-center flex-col space-y-4">
       <img src="assets/calculator.svg" alt="Calculator icon" class="w-10 h-10"/>
       <h1 class="text-2xl font-bold">Print Capacity Calculator</h1>
       <p class="text-sm leading-relaxed text-left">
@@ -53,6 +54,7 @@
       <button id="assumptions-btn" class="bg-white text-orange-800 font-semibold px-4 py-2 rounded shadow mt-auto">Calculator Assumptions</button>
     </aside>
     <section class="md:flex-1 bg-white/80 backdrop-blur-md shadow-lg p-6 rounded-lg">
+      <div id="version-info" class="hidden bg-yellow-100 text-yellow-800 border-l-4 border-yellow-400 p-3 rounded mb-4"></div>
       <div class="space-y-4">
         <div class="space-y-1">
           <label for="labels-per-page" class="font-medium">Labels per page: <span id="labels-per-page-value"></span></label>
@@ -60,7 +62,7 @@
         </div>
         <div class="space-y-1">
           <label for="total-labels" class="font-medium">Total labels: <span id="total-labels-value"></span></label>
-          <input type="range" id="total-labels" min="1000" max="100000" value="30000" class="w-full transition-all duration-300 rounded-lg">
+          <input type="range" id="total-labels" min="1000" max="100000" value="30000" step="100" class="w-full transition-all duration-300 rounded-lg">
         </div>
         <div class="space-y-1">
           <label for="copies" class="font-medium">Copies: <span id="copies-value"></span></label>

--- a/script.js
+++ b/script.js
@@ -72,7 +72,7 @@ function setVersion(version) {
   } else if (version === 'v11.6') {
     driver.classList.remove('hidden');
     labels.classList.remove('hidden');
-    info.textContent = '⚠️ Version 11.6 is still in progress and will be available in August.';
+    info.textContent = '⚠️ Version 11.6 is still in progress and will be available in August';
     info.classList.remove('hidden');
   }
 }


### PR DESCRIPTION
## Summary
- add full-width version tab bar with centered buttons
- move version 11.6 warning banner into calculator panel
- lighten the description panel background
- add `step="100"` to Total labels range
- tweak version 11.6 warning text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862d7b4dff083249f9bd57279c2e802