### PR TITLE
Update styles for calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     </div>
   </div>
   <main class="container mx-auto p-4 flex flex-col md:flex-row gap-4 fade-in">
-    <aside class="md:w-1/3 bg-orange-300 text-orange-900 backdrop-blur-lg p-6 rounded-lg flex items-center text-center flex-col space-y-4">
+    <aside class="md:w-1/3 text-white backdrop-blur-lg p-6 rounded-lg flex items-center text-center flex-col space-y-4" style="background-color: rgb(222,90,0);">
       <img src="assets/calculator.svg" alt="Calculator icon" class="w-10 h-10"/>
       <h1 class="text-2xl font-bold">Print Capacity Calculator</h1>
       <p class="text-sm leading-relaxed text-left">
@@ -51,9 +51,9 @@
           <li>Avoid unexpected delays in label production</li>
         </ul>
       </p>
-      <button id="assumptions-btn" class="bg-white text-orange-800 font-semibold px-4 py-2 rounded shadow mt-auto">Calculator Assumptions</button>
-    </aside>
-    <section class="md:flex-1 bg-white/80 backdrop-blur-md shadow-lg p-6 rounded-lg">
+        <button id="assumptions-btn" class="text-[rgb(222,90,0)] bg-white font-semibold px-4 py-2 rounded shadow mt-auto">Calculator Assumptions</button>
+      </aside>
+      <section class="md:flex-1 bg-white/90 backdrop-blur-md shadow-lg p-6 rounded-lg">
       <div id="version-info" class="hidden bg-yellow-100 text-yellow-800 border-l-4 border-yellow-400 p-3 rounded mb-4"></div>
       <div class="space-y-4">
         <div class="space-y-1">
@@ -62,7 +62,7 @@
         </div>
         <div class="space-y-1">
           <label for="total-labels" class="font-medium">Total labels: <span id="total-labels-value"></span></label>
-          <input type="range" id="total-labels" min="1000" max="100000" value="30000" step="100" class="w-full transition-all duration-300 rounded-lg">
+          <input type="range" id="total-labels" min="1000" max="100000" value="30000" step="500" class="w-full transition-all duration-300 rounded-lg">
         </div>
         <div class="space-y-1">
           <label for="copies" class="font-medium">Copies: <span id="copies-value"></span></label>


### PR DESCRIPTION
## Summary
- apply white text and custom orange background to the left panel
- color the assumptions button orange
- step total labels slider in 500s
- increase main panel opacity

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6862dc98c1b88324b312dd9c479b321b