### PR TITLE
Add developer options panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,8 +54,23 @@
         <button id="assumptions-btn" class="text-[rgb(222,90,0)] bg-white font-semibold px-4 py-2 rounded shadow mt-auto">Calculator Assumptions</button>
       </aside>
       <section class="md:flex-1 bg-white/90 backdrop-blur-md shadow-lg p-6 rounded-lg">
-      <div id="version-info" class="hidden bg-yellow-100 text-yellow-800 border-l-4 border-yellow-400 p-3 rounded mb-4"></div>
-      <div class="space-y-4">
+        <div class="flex justify-end">
+          <button id="technical-btn" class="text-xl p-1" aria-label="Technical Settings">🔧</button>
+        </div>
+        <div id="technical-settings" class="overflow-hidden max-h-0 opacity-0 transition-all duration-300">
+          <div class="border rounded p-4 bg-gray-50 space-y-2">
+            <label class="flex items-center space-x-2">
+              <input type="checkbox" id="developer-toggle" class="rounded">
+              <span class="font-medium">Developer Options</span>
+            </label>
+            <div id="executor-section" class="space-y-1">
+              <label for="executor-count" class="font-medium">BTXML Executor Instances: <span id="executor-count-value"></span></label>
+              <input type="range" id="executor-count" min="1" max="10" value="3" class="w-full transition-all duration-300 rounded-lg">
+            </div>
+          </div>
+        </div>
+        <div id="version-info" class="hidden bg-yellow-100 text-yellow-800 border-l-4 border-yellow-400 p-3 rounded mb-4"></div>
+        <div class="space-y-4">
         <div class="space-y-1">
           <label for="labels-per-page" class="font-medium">Labels per page: <span id="labels-per-page-value"></span></label>
           <input type="range" id="labels-per-page" min="1" max="20" value="10" class="w-full transition-all duration-300 rounded-lg">
@@ -90,10 +105,11 @@
             <label class="inline-flex items-center space-x-2"><input type="checkbox" id="external-data" class="rounded"> <span>Accesses external data sources</span></label>
           </div>
         </fieldset>
-        <div id="results" class="mt-4 p-4 rounded-md bg-white shadow-md text-right text-blue-800 space-y-1 transition-transform">
-          <p class="font-semibold">🧮 Total pages: <span id="total-pages" class="font-bold">0</span></p>
-          <p class="font-semibold">⏱️ Estimated time: <span id="total-time" class="font-bold">0s</span></p>
-        </div>
+          <div id="results" class="mt-4 p-4 rounded-md bg-white shadow-md text-right text-blue-800 space-y-1 transition-transform">
+            <p class="font-semibold">🧮 Total pages: <span id="total-pages" class="font-bold">0</span></p>
+            <p class="font-semibold">⏱️ Estimated time: <span id="total-time" class="font-bold">0s</span></p>
+            <p id="cloud-time-row" class="font-semibold hidden">☁️ Cloud Processing Time: <span id="cloud-time" class="font-bold">N/A</span></p>
+          </div>
       </div>
     </section>
   </main>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
 let currentVersion = 'v11.5';
+let developerOptionsEnabled = false;
 
 function updateDisplay(inputId, valueId) {
   const input = document.getElementById(inputId);
@@ -29,6 +30,14 @@ function animateResults() {
   setTimeout(() => box.classList.remove('flash'), 300);
 }
 
+function updateTechnicalVisibility() {
+  const execSection = document.getElementById('executor-section');
+  const cloudRow = document.getElementById('cloud-time-row');
+  const show = developerOptionsEnabled && (currentVersion === 'v11.5' || currentVersion === 'v11.6');
+  if (execSection) execSection.classList.toggle('hidden', !show);
+  if (cloudRow) cloudRow.classList.toggle('hidden', !show);
+}
+
 function calculate() {
   const labelsPerPage = parseInt(document.getElementById('labels-per-page').value, 10);
   const totalLabels = parseInt(document.getElementById('total-labels').value, 10);
@@ -45,6 +54,19 @@ function calculate() {
 
   document.getElementById('total-pages').textContent = totalPages;
   document.getElementById('total-time').textContent = formatTime(seconds);
+
+  let cloud = NaN;
+  if (developerOptionsEnabled && (currentVersion === 'v11.5' || currentVersion === 'v11.6')) {
+    const count = parseInt(document.getElementById('executor-count').value, 10);
+    const raw = 4659.91 - 478.055 * Math.log(1733.93 - 1562.24 * count);
+    if (!isNaN(raw) && isFinite(raw)) {
+      cloud = parseFloat(raw.toFixed(2));
+    }
+  }
+  const cloudEl = document.getElementById('cloud-time');
+  if (cloudEl) {
+    cloudEl.textContent = !isNaN(cloud) ? cloud : 'N/A';
+  }
   animateResults();
 }
 
@@ -83,6 +105,7 @@ function setVersion(version) {
     info.textContent = '⚠️ Version 11.6 is still in progress and will be available in August';
     info.classList.remove('hidden');
   }
+  updateTechnicalVisibility();
   calculate();
 }
 
@@ -97,6 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
   bindInput('contains-images');
   bindInput('contains-barcodes');
   bindInput('external-data');
+  bindInput('executor-count', 'executor-count-value');
   calculate();
   const tabs = document.querySelectorAll('.version-tab');
   tabs.forEach(t => t.addEventListener('click', () => setVersion(t.dataset.version)));
@@ -107,4 +131,29 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('faq').scrollIntoView({ behavior: 'smooth' });
     });
   }
+  const techBtn = document.getElementById('technical-btn');
+  if (techBtn) {
+    techBtn.addEventListener('click', () => {
+      const sec = document.getElementById('technical-settings');
+      if (!sec) return;
+      const closed = sec.classList.contains('max-h-0');
+      if (closed) {
+        sec.classList.remove('max-h-0', 'opacity-0');
+        sec.classList.add('max-h-96', 'opacity-100');
+      } else {
+        sec.classList.add('max-h-0', 'opacity-0');
+        sec.classList.remove('max-h-96', 'opacity-100');
+      }
+    });
+  }
+  const devToggle = document.getElementById('developer-toggle');
+  if (devToggle) {
+    developerOptionsEnabled = devToggle.checked;
+    devToggle.addEventListener('change', () => {
+      developerOptionsEnabled = devToggle.checked;
+      updateTechnicalVisibility();
+      calculate();
+    });
+  }
+  updateTechnicalVisibility();
 });


### PR DESCRIPTION
## Summary
- introduce a collapsible technical settings panel
- allow enabling Developer Options and tweaking BTXML executor instances
- compute and display Cloud Processing Time for versions 11.5 and 11.6

## Testing
- `node --check script.js`
- `npm start` *(fails: npm tried to reach the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68654efa4bb88324a41752baf6bff2e9