### PR TITLE
Add developer toggle and cloud time logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,20 +54,14 @@
         <button id="assumptions-btn" class="text-[rgb(222,90,0)] bg-white font-semibold px-4 py-2 rounded shadow mt-auto">Calculator Assumptions</button>
       </aside>
       <section class="md:flex-1 bg-white/90 backdrop-blur-md shadow-lg p-6 rounded-lg">
-        <div class="flex justify-end">
-          <button id="technical-btn" class="text-xl p-1" aria-label="Technical Settings">🔧</button>
-        </div>
-        <div id="technical-settings" class="overflow-hidden max-h-0 opacity-0 transition-all duration-300">
-          <div class="border rounded p-4 bg-gray-50 space-y-2">
-            <label class="flex items-center space-x-2">
-              <input type="checkbox" id="developer-toggle" class="rounded">
-              <span class="font-medium">Developer Options</span>
-            </label>
-            <div id="executor-section" class="space-y-1">
-              <label for="executor-count" class="font-medium">BTXML Executor Instances: <span id="executor-count-value"></span></label>
-              <input type="range" id="executor-count" min="1" max="10" value="3" class="w-full transition-all duration-300 rounded-lg">
+        <div class="flex justify-end mb-4">
+          <label class="inline-flex items-center cursor-pointer">
+            <input type="checkbox" id="developer-toggle" class="sr-only peer">
+            <div class="w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-blue-500 transition duration-300 relative">
+              <span class="absolute left-1 top-1 w-4 h-4 bg-white rounded-full transition-transform duration-300 peer-checked:translate-x-5"></span>
             </div>
-          </div>
+            <span class="ml-2 text-sm font-medium">Developer Options</span>
+          </label>
         </div>
         <div id="version-info" class="hidden bg-yellow-100 text-yellow-800 border-l-4 border-yellow-400 p-3 rounded mb-4"></div>
         <div class="space-y-4">
@@ -90,6 +84,10 @@
         <div class="space-y-1">
           <label for="gateways" class="font-medium">Print gateways: <span id="gateways-value"></span></label>
           <input type="range" id="gateways" min="1" max="10" value="1" class="w-full transition-all duration-300 rounded-lg">
+        </div>
+        <div id="executor-section" class="space-y-1 hidden">
+          <label for="executor-count" class="font-medium">BTXML Executor Instances: <span id="executor-count-value"></span></label>
+          <input type="range" id="executor-count" min="1" max="10" value="3" class="w-full transition-all duration-300 rounded-lg">
         </div>
         <div id="optimized-driver-section" class="flex items-center space-x-2">
           <input type="checkbox" id="optimized-driver" class="transition-all duration-300 rounded">

--- a/script.js
+++ b/script.js
@@ -53,16 +53,17 @@ function calculate() {
   }
 
   document.getElementById('total-pages').textContent = totalPages;
-  document.getElementById('total-time').textContent = formatTime(seconds);
 
   let cloud = NaN;
   if (developerOptionsEnabled && (currentVersion === 'v11.5' || currentVersion === 'v11.6')) {
     const count = parseInt(document.getElementById('executor-count').value, 10);
-    const raw = 4659.91 - 478.055 * Math.log(1733.93 - 1562.24 * count);
+    const raw = 0.000489511 * totalLabels - 10.85582423 * count + 33.472078991926;
     if (!isNaN(raw) && isFinite(raw)) {
       cloud = parseFloat(raw.toFixed(2));
     }
   }
+  const finalSeconds = !isNaN(cloud) && cloud > seconds ? cloud : seconds;
+  document.getElementById('total-time').textContent = formatTime(finalSeconds);
   const cloudEl = document.getElementById('cloud-time');
   if (cloudEl) {
     cloudEl.textContent = !isNaN(cloud) ? cloud : 'N/A';
@@ -129,21 +130,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (btn) {
     btn.addEventListener('click', () => {
       document.getElementById('faq').scrollIntoView({ behavior: 'smooth' });
-    });
-  }
-  const techBtn = document.getElementById('technical-btn');
-  if (techBtn) {
-    techBtn.addEventListener('click', () => {
-      const sec = document.getElementById('technical-settings');
-      if (!sec) return;
-      const closed = sec.classList.contains('max-h-0');
-      if (closed) {
-        sec.classList.remove('max-h-0', 'opacity-0');
-        sec.classList.add('max-h-96', 'opacity-100');
-      } else {
-        sec.classList.add('max-h-0', 'opacity-0');
-        sec.classList.remove('max-h-96', 'opacity-100');
-      }
     });
   }
   const devToggle = document.getElementById('developer-toggle');


### PR DESCRIPTION
## Summary
- replace technical settings gear with a toggle switch labelled *Developer Options*
- add Executor slider below Print Gateways when developer mode is enabled
- implement new cloud processing time formula and compare against local time
- update Estimated Time display to show the larger of local or cloud time

## Testing
- `npm start` *(fails: internet blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68658ca2c41c8324992bc6742c898159