### PR TITLE
Fix toggle and update estimate logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,11 +55,10 @@
       </aside>
       <section class="md:flex-1 bg-white/90 backdrop-blur-md shadow-lg p-6 rounded-lg">
         <div class="flex justify-end mb-4">
-          <label class="inline-flex items-center cursor-pointer">
+          <label class="relative inline-flex items-center cursor-pointer">
             <input type="checkbox" id="developer-toggle" class="sr-only peer">
-            <div class="w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-blue-500 transition duration-300 relative">
-              <span class="absolute left-1 top-1 w-4 h-4 bg-white rounded-full transition-transform duration-300 peer-checked:translate-x-5"></span>
-            </div>
+            <div class="w-11 h-6 bg-gray-300 rounded-full peer-checked:bg-blue-500"></div>
+            <div class="absolute left-1 top-1 w-4 h-4 bg-white rounded-full transition-transform duration-300 peer-checked:translate-x-5"></div>
             <span class="ml-2 text-sm font-medium">Developer Options</span>
           </label>
         </div>

--- a/script.js
+++ b/script.js
@@ -33,9 +33,9 @@ function animateResults() {
 function updateTechnicalVisibility() {
   const execSection = document.getElementById('executor-section');
   const cloudRow = document.getElementById('cloud-time-row');
-  const show = developerOptionsEnabled && (currentVersion === 'v11.5' || currentVersion === 'v11.6');
-  if (execSection) execSection.classList.toggle('hidden', !show);
-  if (cloudRow) cloudRow.classList.toggle('hidden', !show);
+  const v115Or116 = currentVersion === 'v11.5' || currentVersion === 'v11.6';
+  if (execSection) execSection.classList.toggle('hidden', !(developerOptionsEnabled && v115Or116));
+  if (cloudRow) cloudRow.classList.toggle('hidden', !v115Or116);
 }
 
 function calculate() {
@@ -55,14 +55,18 @@ function calculate() {
   document.getElementById('total-pages').textContent = totalPages;
 
   let cloud = NaN;
-  if (developerOptionsEnabled && (currentVersion === 'v11.5' || currentVersion === 'v11.6')) {
+  if (currentVersion === 'v11.5' || currentVersion === 'v11.6') {
     const count = parseInt(document.getElementById('executor-count').value, 10);
     const raw = 0.000489511 * totalLabels - 10.85582423 * count + 33.472078991926;
     if (!isNaN(raw) && isFinite(raw)) {
       cloud = parseFloat(raw.toFixed(2));
     }
   }
-  const finalSeconds = !isNaN(cloud) && cloud > seconds ? cloud : seconds;
+
+  let finalSeconds = seconds;
+  if (!isNaN(cloud) && (currentVersion === 'v11.5' || currentVersion === 'v11.6') && cloud > seconds) {
+    finalSeconds = cloud;
+  }
   document.getElementById('total-time').textContent = formatTime(finalSeconds);
   const cloudEl = document.getElementById('cloud-time');
   if (cloudEl) {


### PR DESCRIPTION
## Summary
- make the Developer Options toggle use peer-based sliding knob
- update visibility logic so Cloud Time shows for v11.5/v11.6
- compute cloud time for v11.5/v11.6 and override Estimated Time when greater

## Testing
- `npm start` *(server runs)*

------
https://chatgpt.com/codex/tasks/task_e_687924658cd883248eee18a9c9c94e7f